### PR TITLE
All 3 domains (fc, cl and periph) now have seperate IDs so that they …

### DIFF
--- a/include/pmsis/rtos/os_frontend_api/pmsis_freq.h
+++ b/include/pmsis/rtos/os_frontend_api/pmsis_freq.h
@@ -20,7 +20,7 @@
 typedef enum {
   PI_FREQ_DOMAIN_FC     = 0,
   PI_FREQ_DOMAIN_CL     = 1,
-  PI_FREQ_DOMAIN_PERIPH = 0
+  PI_FREQ_DOMAIN_PERIPH = 2
 } pi_freq_domain_e;
 
 /** \brief Get current frequency of a domain.


### PR DESCRIPTION
…can be mapped to different real domains
Siva, I need to have separate IDs for each domain to fit other chips, I think this impact pmsis drivers as FC and periph are the same domain, could you check what this modification is impacting ?