### PR TITLE
Update i2s driver: add shift value in config

### DIFF
--- a/include/pmsis/drivers/i2s.h
+++ b/include/pmsis/drivers/i2s.h
@@ -115,9 +115,10 @@ enum pi_i2s_ioctl_cmd {
  * @param block_size Size of one RX/TX memory block (buffer) in bytes.
  * @param pingpong_buffers Pair of buffers used in double-buffering mode to
  *   capture the incoming samples.
- * @param pdm_decimation_log2 In PDM mode, this gives the log2 of the
- *   decimation to be used, e.g. the number of bits on which the filter
- *   is applied.
+ * @param pdm_decimation In PDM mode, this gives the decimation factor
+ *   to be used, e.g. the number of bits on which the filter is applied.
+ * @param pdm_shift In PDM mode, the shift value to shift data when applying
+ *   filter.
  */
 struct pi_i2s_conf {
     uint8_t word_size;
@@ -128,7 +129,8 @@ struct pi_i2s_conf {
     uint32_t frame_clk_freq;
     size_t block_size;
     void *pingpong_buffers[2];
-    uint16_t pdm_decimation_log2;
+    uint16_t pdm_decimation;
+    int8_t pdm_shift;
 };
 
 /** \brief Initialize an I2S configuration with default values.


### PR DESCRIPTION
Add shift value in conf. If set, it sets shift value used in filter decimation, otherwise it is used to set default values for the filter.