### PR TITLE
Synchronize arguments in declaration and implementation

### DIFF
--- a/include/pmsis/cluster/cluster_sync/fc_to_cl_delegate.h
+++ b/include/pmsis/cluster/cluster_sync/fc_to_cl_delegate.h
@@ -173,8 +173,8 @@ static inline int pi_cluster_send_task(struct pi_device *device,
  * \param end_task        The task used to notify the end of execution.
  */
 static inline int pi_cluster_send_task_async(struct pi_device *device,
-        struct pi_cluster_task *task,
-        pi_task_t *end_task);
+        struct pi_cluster_task *cluster_task,
+        pi_task_t *task);
 
 //!@}
 


### PR DESCRIPTION
Fixes the following cppcheck warning:

  Function 'pi_cluster_send_task_async' argument order different: declaration 'device, task, end_task' definition 'device, cluster_task, task'